### PR TITLE
object store volume groups

### DIFF
--- a/src/client/main.c
+++ b/src/client/main.c
@@ -40,7 +40,7 @@ static void process_connection(int fd, void *arg)
 
 int main(int argc, char **argv)
 {
-	struct objstore *store;
+	struct objstore_vol *vol;
 	int ret;
 
 	/*
@@ -62,22 +62,22 @@ int main(int argc, char **argv)
 		goto err;
 	}
 
-	store = objstore_store_create("abc", OS_MODE_STORE);
-	fprintf(stderr, "store = %p\n", store);
+	vol = objstore_vol_create("abc", OS_MODE_STORE);
+	fprintf(stderr, "vol = %p\n", vol);
 
-	if (IS_ERR(store)) {
-		ret = PTR_ERR(store);
+	if (IS_ERR(vol)) {
+		ret = PTR_ERR(vol);
 		fprintf(stderr, "error: %s\n", strerror(ret));
-		goto err_objstore;
+		goto err_vol;
 	}
 
-	ret = connsvc(NULL, CLIENT_DAEMON_PORT, process_connection, store);
+	ret = connsvc(NULL, CLIENT_DAEMON_PORT, process_connection, vol);
 
 	fprintf(stderr, "connsvc() = %d (%s)\n", ret, strerror(ret));
 
-	/* XXX: undo objstore_store_create() */
+	/* XXX: undo objstore_vol_create() */
 
-err_objstore:
+err_vol:
 	/* XXX: undo objstore_init() */
 
 err:

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
 		goto err_init;
 	}
 
-	vol = objstore_vol_create("abc", OS_MODE_STORE);
+	vol = objstore_vol_create(vg, "fauxpath", OS_MODE_STORE);
 	fprintf(stderr, "vol = %p\n", vol);
 
 	if (IS_ERR(vol)) {

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -40,6 +40,7 @@ static void process_connection(int fd, void *arg)
 
 int main(int argc, char **argv)
 {
+	struct objstore *vg;
 	struct objstore_vol *vol;
 	int ret;
 
@@ -62,22 +63,34 @@ int main(int argc, char **argv)
 		goto err;
 	}
 
+	vg = objstore_vg_create("myfiles");
+	fprintf(stderr, "vg = %p\n", vg);
+
+	if (IS_ERR(vg)) {
+		ret = PTR_ERR(vg);
+		fprintf(stderr, "error: %s\n", strerror(ret));
+		goto err_init;
+	}
+
 	vol = objstore_vol_create("abc", OS_MODE_STORE);
 	fprintf(stderr, "vol = %p\n", vol);
 
 	if (IS_ERR(vol)) {
 		ret = PTR_ERR(vol);
 		fprintf(stderr, "error: %s\n", strerror(ret));
-		goto err_vol;
+		goto err_vg;
 	}
 
-	ret = connsvc(NULL, CLIENT_DAEMON_PORT, process_connection, vol);
+	ret = connsvc(NULL, CLIENT_DAEMON_PORT, process_connection, vg);
 
 	fprintf(stderr, "connsvc() = %d (%s)\n", ret, strerror(ret));
 
 	/* XXX: undo objstore_vol_create() */
 
-err_vol:
+err_vg:
+	/* XXX: undo objstore_vg_create() */
+
+err_init:
 	/* XXX: undo objstore_init() */
 
 err:

--- a/src/objstore/CMakeLists.txt
+++ b/src/objstore/CMakeLists.txt
@@ -22,10 +22,12 @@
 
 add_library(nomad_objstore SHARED
 	objstore.c
+	vg.c
 )
 
 target_link_libraries(nomad_objstore
 	${BASE_LIBS}
+	${LIST_LIBRARY}
 	dl
 )
 

--- a/src/objstore/include/nomad/objstore.h
+++ b/src/objstore/include/nomad/objstore.h
@@ -30,10 +30,10 @@ enum objstore_mode {
 	OS_MODE_STORE,
 };
 
-struct objstore_def;
+struct objstore_vol_def;
 
-struct objstore {
-	const struct objstore_def *def;
+struct objstore_vol {
+	const struct objstore_vol_def *def;
 
 	struct nuuid uuid;
 	const char *path;
@@ -43,15 +43,18 @@ struct objstore {
 };
 
 extern int objstore_init(void);
-extern struct objstore *objstore_store_create(const char *path,
-					      enum objstore_mode mode);
-extern struct objstore *objstore_store_load(struct nuuid *uuid, const char *path);
 
-/* store operations */
-extern int objstore_getroot(struct objstore *store, struct nobjhndl *hndl);
+/* volume management */
+extern struct objstore_vol *objstore_vol_create(const char *path,
+						enum objstore_mode mode);
+extern struct objstore_vol *objstore_vol_load(struct nuuid *uuid,
+					      const char *path);
+
+/* volume operations */
+extern int objstore_getroot(struct objstore_vol *store, struct nobjhndl *hndl);
 
 /* object operations */
-extern int objstore_obj_getattr(struct objstore *store,
+extern int objstore_obj_getattr(struct objstore_vol *store,
 				const struct nobjhndl *hndl,
 				struct nattr *attr);
 

--- a/src/objstore/include/nomad/objstore.h
+++ b/src/objstore/include/nomad/objstore.h
@@ -23,6 +23,8 @@
 #ifndef __NOMAD_OBJSTORE_H
 #define __NOMAD_OBJSTORE_H
 
+#include <sys/list.h>
+
 #include <nomad/types.h>
 
 enum objstore_mode {
@@ -30,9 +32,19 @@ enum objstore_mode {
 	OS_MODE_STORE,
 };
 
+struct objstore {
+	list_node_t vgs;
+
+	const char *name;
+	list_t vols;		/* list of volumes */
+};
+
 struct objstore_vol_def;
 
 struct objstore_vol {
+	list_node_t vg_list;
+	struct objstore *vg;
+
 	const struct objstore_vol_def *def;
 
 	struct nuuid uuid;
@@ -43,6 +55,9 @@ struct objstore_vol {
 };
 
 extern int objstore_init(void);
+
+/* volume group management */
+extern struct objstore *objstore_vg_create(const char *name);
 
 /* volume management */
 extern struct objstore_vol *objstore_vol_create(const char *path,

--- a/src/objstore/include/nomad/objstore.h
+++ b/src/objstore/include/nomad/objstore.h
@@ -26,6 +26,7 @@
 #include <sys/list.h>
 
 #include <nomad/types.h>
+#include <nomad/mutex.h>
 
 enum objstore_mode {
 	OS_MODE_CACHE,
@@ -35,6 +36,7 @@ enum objstore_mode {
 struct objstore {
 	list_node_t vgs;
 
+	pthread_mutex_t lock;
 	const char *name;
 	list_t vols;		/* list of volumes */
 };
@@ -60,9 +62,11 @@ extern int objstore_init(void);
 extern struct objstore *objstore_vg_create(const char *name);
 
 /* volume management */
-extern struct objstore_vol *objstore_vol_create(const char *path,
+extern struct objstore_vol *objstore_vol_create(struct objstore *vg,
+						const char *path,
 						enum objstore_mode mode);
-extern struct objstore_vol *objstore_vol_load(struct nuuid *uuid,
+extern struct objstore_vol *objstore_vol_load(struct objstore *vg,
+					      struct nuuid *uuid,
 					      const char *path);
 
 /* volume operations */

--- a/src/objstore/include/nomad/objstore_impl.h
+++ b/src/objstore/include/nomad/objstore_impl.h
@@ -25,10 +25,10 @@
 
 #include <nomad/objstore.h>
 
-struct objstore_ops {
-	int (*create)(struct objstore *store);
-	int (*load)(struct objstore *store);
-	int (*getroot)(struct objstore *store, struct nobjhndl *hndl);
+struct vol_ops {
+	int (*create)(struct objstore_vol *store);
+	int (*load)(struct objstore_vol *store);
+	int (*getroot)(struct objstore_vol *store, struct nobjhndl *hndl);
 };
 
 struct obj_ops {
@@ -47,16 +47,16 @@ struct obj_ops {
 	int (*commit)();	/* make temp object live */
 	int (*abort)();		/* delete temp object */
 
-	int (*getattr)(struct objstore *store, const struct nobjhndl *hndl,
+	int (*getattr)(struct objstore_vol *store, const struct nobjhndl *hndl,
 		       struct nattr *attr);
 	int (*setattr)();	/* set attributes of an object */
 	ssize_t (*read)();	/* read portion of an object */
 	ssize_t (*write)();	/* write portion of an object */
 };
 
-struct objstore_def {
+struct objstore_vol_def {
 	const char *name;
-	const struct objstore_ops *store_ops;
+	const struct vol_ops *vol_ops;
 	const struct obj_ops *obj_ops;
 };
 

--- a/src/objstore/include/nomad/objstore_impl.h
+++ b/src/objstore/include/nomad/objstore_impl.h
@@ -60,6 +60,8 @@ struct objstore_vol_def {
 	const struct obj_ops *obj_ops;
 };
 
+/* internal volume group management helpers */
 extern int objstore_vg_init(void);
+extern void objstore_vg_add_vol(struct objstore *vg, struct objstore_vol *vol);
 
 #endif

--- a/src/objstore/mem/main.c
+++ b/src/objstore/mem/main.c
@@ -104,7 +104,7 @@ err:
 	return ERR_PTR(ret);
 }
 
-static int mem_store_create(struct objstore *store)
+static int mem_vol_create(struct objstore_vol *store)
 {
 	struct memstore *ms;
 	struct memobj *obj;
@@ -135,7 +135,7 @@ static int mem_store_create(struct objstore *store)
 	return 0;
 }
 
-static int mem_store_getroot(struct objstore *store, struct nobjhndl *hndl)
+static int mem_vol_getroot(struct objstore_vol *store, struct nobjhndl *hndl)
 {
 	struct memstore *ms;
 
@@ -153,16 +153,16 @@ static int mem_store_getroot(struct objstore *store, struct nobjhndl *hndl)
 	return 0;
 }
 
-static const struct objstore_ops store_ops = {
-	.create = mem_store_create,
-	.getroot = mem_store_getroot,
+static const struct vol_ops vol_ops = {
+	.create = mem_vol_create,
+	.getroot = mem_vol_getroot,
 };
 
 static const struct obj_ops obj_ops = {
 };
 
-const struct objstore_def objstore = {
+const struct objstore_vol_def objvol = {
 	.name = "mem",
-	.store_ops = &store_ops,
+	.vol_ops = &vol_ops,
 	.obj_ops = &obj_ops,
 };

--- a/src/objstore/objstore.c
+++ b/src/objstore/objstore.c
@@ -77,7 +77,8 @@ int objstore_init(void)
 	return 0;
 }
 
-struct objstore_vol *objstore_vol_create(const char *path, enum objstore_mode mode)
+struct objstore_vol *objstore_vol_create(struct objstore *vg, const char *path,
+					 enum objstore_mode mode)
 {
 	struct objstore_vol *s;
 	int ret;
@@ -101,6 +102,8 @@ struct objstore_vol *objstore_vol_create(const char *path, enum objstore_mode mo
 	if (ret)
 		goto err_path;
 
+	objstore_vg_add_vol(vg, s);
+
 	return s;
 
 err_path:
@@ -112,7 +115,8 @@ err:
 	return ERR_PTR(ret);
 }
 
-struct objstore_vol *objstore_vol_load(struct nuuid *uuid, const char *path)
+struct objstore_vol *objstore_vol_load(struct objstore *vg, struct nuuid *uuid,
+				       const char *path)
 {
 	return ERR_PTR(ENOTSUP);
 }

--- a/src/objstore/objstore.c
+++ b/src/objstore/objstore.c
@@ -64,6 +64,10 @@ int objstore_init(void)
 {
 	int ret;
 
+	ret = objstore_vg_init();
+	if (ret)
+		return ret;
+
 	ret = load_backend(&mem_backend, "mem");
 	if (ret)
 		return ret;

--- a/src/objstore/posix/main.c
+++ b/src/objstore/posix/main.c
@@ -23,14 +23,14 @@
 #include <nomad/error.h>
 #include <nomad/objstore_impl.h>
 
-static const struct objstore_ops store_ops = {
+static const struct vol_ops vol_ops = {
 };
 
 static const struct obj_ops obj_ops = {
 };
 
-const struct objstore_def objstore = {
+const struct objstore_vol_def objvol = {
 	.name = "posix",
-	.store_ops = &store_ops,
+	.vol_ops = &vol_ops,
 	.obj_ops = &obj_ops,
 };

--- a/src/objstore/vg.c
+++ b/src/objstore/vg.c
@@ -20,46 +20,52 @@
  * SOFTWARE.
  */
 
-#ifndef __NOMAD_OBJSTORE_IMPL_H
-#define __NOMAD_OBJSTORE_IMPL_H
+#include <stddef.h>
 
+#include <nomad/error.h>
+#include <nomad/mutex.h>
 #include <nomad/objstore.h>
+#include <nomad/objstore_impl.h>
 
-struct vol_ops {
-	int (*create)(struct objstore_vol *store);
-	int (*load)(struct objstore_vol *store);
-	int (*getroot)(struct objstore_vol *store, struct nobjhndl *hndl);
-};
+static pthread_mutex_t vgs_lock;
+static list_t vgs;
 
-struct obj_ops {
-	int (*getversions)();
+int objstore_vg_init(void)
+{
+	struct objstore *filecache;
 
-	/* open objects must be closed */
-	int (*open)();		/* open an object */
-	int (*close)();		/* close an object */
+	mxinit(&vgs_lock);
 
-	/* created/cloned objects must be committed/aborted */
-	int (*create)();	/* create a new temp object */
-	int (*clone)();		/*
-				 * create a new temp obj as a copy of
-				 * existing obj
-				 */
-	int (*commit)();	/* make temp object live */
-	int (*abort)();		/* delete temp object */
+	list_create(&vgs, sizeof(struct objstore),
+		    offsetof(struct objstore, vgs));
 
-	int (*getattr)(struct objstore_vol *store, const struct nobjhndl *hndl,
-		       struct nattr *attr);
-	int (*setattr)();	/* set attributes of an object */
-	ssize_t (*read)();	/* read portion of an object */
-	ssize_t (*write)();	/* write portion of an object */
-};
+	filecache = objstore_vg_create("file$");
+	if (IS_ERR(filecache))
+		return PTR_ERR(filecache);
 
-struct objstore_vol_def {
-	const char *name;
-	const struct vol_ops *vol_ops;
-	const struct obj_ops *obj_ops;
-};
+	return 0;
+}
 
-extern int objstore_vg_init(void);
+struct objstore *objstore_vg_create(const char *name)
+{
+	struct objstore *vg;
 
-#endif
+	vg = malloc(sizeof(struct objstore));
+	if (!vg)
+		return ERR_PTR(ENOMEM);
+
+	vg->name = strdup(name);
+	if (!vg->name) {
+		free(vg);
+		return ERR_PTR(ENOMEM);
+	}
+
+	list_create(&vg->vols, sizeof(struct objstore_vol),
+		    offsetof(struct objstore_vol, vg_list));
+
+	mxlock(&vgs_lock);
+	list_insert_tail(&vgs, vg);
+	mxunlock(&vgs_lock);
+
+	return vg;
+}

--- a/src/objstore/vg.c
+++ b/src/objstore/vg.c
@@ -23,7 +23,6 @@
 #include <stddef.h>
 
 #include <nomad/error.h>
-#include <nomad/mutex.h>
 #include <nomad/objstore.h>
 #include <nomad/objstore_impl.h>
 
@@ -63,9 +62,18 @@ struct objstore *objstore_vg_create(const char *name)
 	list_create(&vg->vols, sizeof(struct objstore_vol),
 		    offsetof(struct objstore_vol, vg_list));
 
+	mxinit(&vg->lock);
+
 	mxlock(&vgs_lock);
 	list_insert_tail(&vgs, vg);
 	mxunlock(&vgs_lock);
 
 	return vg;
+}
+
+void objstore_vg_add_vol(struct objstore *vg, struct objstore_vol *vol)
+{
+	mxlock(&vg->lock);
+	list_insert_tail(&vg->vols, vol);
+	mxunlock(&vg->lock);
 }


### PR DESCRIPTION
They don't do much, but each volume is associated with a volume group.

This is what the in-memory structs look like when running `nomad-client`:

```
> vgs::walk list | ::print struct objstore name
name = 0x808dfd8 "file$"
name = 0x808dfc8 "myfiles"
> vgs::walk list | ::print struct objstore vols | ::walk list | ::print struct o
bjstore_vol
{
    vg_list = {
        list_next = 0x808cf74
        list_prev = 0x808cf74
    }
    vg = 0
    def = libnomad_objstore_mem.so`objvol
    uuid = {
        raw = [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
    }
    path = 0x808ffd0 "fauxpath"
    mode = 0x1 (OS_MODE_STORE)
    private = 0x8090fa0
}
```
