### PR TITLE
build: put binary files in build/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ Makefile
 cmake_install.cmake
 install_manifest.txt
 
+build/
+
 proto
 
 .*.swp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2015 Josef 'Jeff' Sipek <jeffpc@josefsipek.net>
+# Copyright (c) 2015 Joshua Kahn <josh@joshuak.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -32,6 +33,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-inline-functions-called-once")
 
 set(CMAKE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/build")
+set(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/build")
 
 include(cmake/config.cmake)
 include(cmake/rpcgen.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-inline-small-functions")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-inline-functions-called-once")
 
 set(CMAKE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+set(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/build")
 
 include(cmake/config.cmake)
 include(cmake/rpcgen.cmake)


### PR DESCRIPTION
It's convenient to have the executables all in one place.
